### PR TITLE
Add ignore_crc to wav part from sound/journey.zip

### DIFF
--- a/releases/Journey.mra
+++ b/releases/Journey.mra
@@ -49,7 +49,7 @@
 		<part crc="9104c1d0" name="g4"/>
 	</rom>
 	<rom index="2" zip="/sound/journey.zip" address="0x30000000" md5="none" >
-		<part name="sepways.wav"/>
+		<part ignore_crc name="sepways.wav"/>
 	</rom>
 	<nvram index="4" size="2048"/>
 </misterromdescription>


### PR DESCRIPTION
This change allows the mra_rom_check.sh script to pass on this MRA. Otherwise it triggers a CRC not found error.

AFAIK, this parts for wavs don't require a CRC in order to work properly, so we could use "ignore_crc" for these cases.